### PR TITLE
Switch to asyncpg

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import time
+import asyncpg
 
-from quart import Quart, jsonify, request
+from quart import Quart, jsonify, request, current_app
 from db import search
 
 app = Quart(__name__)
@@ -12,10 +13,16 @@ async def index():
     if not query:
         return jsonify({})
     start = time.time()
-    res = search(query)
+    async with current_app.pool.acquire() as connection:
+        res = await search(query, connection)
     return jsonify({
         'time': time.time() - start,
-        'data': res
+        'data': [{k: v for (k,v) in r.items()} for r in res]
     })
+
+@app.before_first_request
+async def create_db():
+    dsn = 'postgres://postgres:postgres@localhost:5432/datagouvfr'
+    app.pool = await asyncpg.create_pool(dsn, max_size=20)
 
 app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Quart
-psycopg2-binary
+asynpg
 csvkit


### PR DESCRIPTION
## before

```
$ hey -n 100 -c 10 http://localhost:5000/?q=entreprises

Summary:
  Total:	10.1903 secs
  Slowest:	1.1938 secs
  Fastest:	0.9220 secs
  Average:	1.0091 secs
  Requests/sec:	9.8133

  Total data:	437384 bytes
  Size/request:	4373 bytes

Response time histogram:
  0.922 [1]	|■
  0.949 [25]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.976 [5]	|■■■■■■■
  1.004 [30]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  1.031 [8]	|■■■■■■■■■■■
  1.058 [7]	|■■■■■■■■■
  1.085 [13]	|■■■■■■■■■■■■■■■■■
  1.112 [0]	|
  1.139 [0]	|
  1.167 [1]	|■
  1.194 [10]	|■■■■■■■■■■■■■


Latency distribution:
  10% in 0.9344 secs
  25% in 0.9491 secs
  50% in 0.9930 secs
  75% in 1.0561 secs
  90% in 1.1746 secs
  95% in 1.1760 secs
  99% in 1.1938 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0005 secs, 0.9220 secs, 1.1938 secs
  DNS-lookup:	0.0004 secs, 0.0000 secs, 0.0049 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0002 secs
  resp wait:	1.0081 secs, 0.9211 secs, 1.1937 secs
  resp read:	0.0003 secs, 0.0000 secs, 0.0043 secs

Status code distribution:
  [200]	100 responses
```

## after

```
hey -n 100 -c 10 http://localhost:5000/?q=entreprises

Summary:
  Total:	3.6662 secs
  Slowest:	0.5615 secs
  Fastest:	0.1085 secs
  Average:	0.3557 secs
  Requests/sec:	27.2760

  Total data:	480329 bytes
  Size/request:	4803 bytes

Response time histogram:
  0.109 [1]	|■■
  0.154 [2]	|■■■
  0.199 [2]	|■■■
  0.244 [6]	|■■■■■■■■■
  0.290 [11]	|■■■■■■■■■■■■■■■■■
  0.335 [19]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.380 [26]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.426 [11]	|■■■■■■■■■■■■■■■■■
  0.471 [11]	|■■■■■■■■■■■■■■■■■
  0.516 [4]	|■■■■■■
  0.561 [7]	|■■■■■■■■■■■


Latency distribution:
  10% in 0.2425 secs
  25% in 0.3022 secs
  50% in 0.3537 secs
  75% in 0.4124 secs
  90% in 0.4895 secs
  95% in 0.5277 secs
  99% in 0.5615 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0005 secs, 0.1085 secs, 0.5615 secs
  DNS-lookup:	0.0004 secs, 0.0000 secs, 0.0042 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0010 secs
  resp wait:	0.3549 secs, 0.1009 secs, 0.5613 secs
  resp read:	0.0001 secs, 0.0001 secs, 0.0015 secs

Status code distribution:
  [200]	100 responses
```