### PR TITLE
Switch to roll

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: hypercorn app.py -b 0.0.0.0:5000
+web: gunicorn pgsearch.app:app --worker-class roll.worker.Worker -b 0.0.0.0:5000
 release: python cmd.py load

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ docker-compose up -d
 sh prepare-data.sh
 python cmd.py load
 python cmd.py fetch_stats
-python app.py
+pip install hupper
+hupper -m pgsearch
 ```
 
-🤜 http://localhost:5000?q=entreprises
+🤜 http://localhost:3579?q=entreprises
 
 ```json
 {

--- a/pgsearch/__main__.py
+++ b/pgsearch/__main__.py
@@ -1,0 +1,6 @@
+from roll.extensions import simple_server
+
+from pgsearch.app import app
+
+
+simple_server(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Quart
+roll
 asyncpg
 csvkit
 minicli


### PR DESCRIPTION
- `quart` seems noticeably faster out the box (cf bench below)
- having a lot less dependencies is nice, especially since I'm now using `minicli` instead of `click`

## roll

`gunicorn pgsearch.app:app --worker-class roll.worker.Worker`

```
hey -n 100 -c 10 http://localhost:8000/?q=entreprises

Summary:
  Total:	5.5687 secs
  Slowest:	0.8266 secs
  Fastest:	0.1176 secs
  Average:	0.5274 secs
  Requests/sec:	17.9574

  Total data:	548318 bytes
  Size/request:	5483 bytes

Response time histogram:
  0.118 [1]	|■
  0.188 [1]	|■
  0.259 [3]	|■■■■
  0.330 [1]	|■
  0.401 [3]	|■■■■
  0.472 [31]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.543 [23]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.614 [10]	|■■■■■■■■■■■■■
  0.685 [11]	|■■■■■■■■■■■■■■
  0.756 [7]	|■■■■■■■■■
  0.827 [9]	|■■■■■■■■■■■■


Latency distribution:
  10% in 0.4092 secs
  25% in 0.4443 secs
  50% in 0.5180 secs
  75% in 0.6287 secs
  90% in 0.7502 secs
  95% in 0.7964 secs
  99% in 0.8266 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0004 secs, 0.1176 secs, 0.8266 secs
  DNS-lookup:	0.0003 secs, 0.0000 secs, 0.0034 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0006 secs
  resp wait:	0.5268 secs, 0.1175 secs, 0.8265 secs
  resp read:	0.0001 secs, 0.0000 secs, 0.0001 secs

Status code distribution:
  [200]	100 responses
```

## quart

`python app.py`

```
hey -n 100 -c 10 http://localhost:5000/?q=entreprises

Summary:
  Total:	3.6662 secs
  Slowest:	0.5615 secs
  Fastest:	0.1085 secs
  Average:	0.3557 secs
  Requests/sec:	27.2760

  Total data:	480329 bytes
  Size/request:	4803 bytes

Response time histogram:
  0.109 [1]	|■■
  0.154 [2]	|■■■
  0.199 [2]	|■■■
  0.244 [6]	|■■■■■■■■■
  0.290 [11]	|■■■■■■■■■■■■■■■■■
  0.335 [19]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.380 [26]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.426 [11]	|■■■■■■■■■■■■■■■■■
  0.471 [11]	|■■■■■■■■■■■■■■■■■
  0.516 [4]	|■■■■■■
  0.561 [7]	|■■■■■■■■■■■


Latency distribution:
  10% in 0.2425 secs
  25% in 0.3022 secs
  50% in 0.3537 secs
  75% in 0.4124 secs
  90% in 0.4895 secs
  95% in 0.5277 secs
  99% in 0.5615 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0005 secs, 0.1085 secs, 0.5615 secs
  DNS-lookup:	0.0004 secs, 0.0000 secs, 0.0042 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0010 secs
  resp wait:	0.3549 secs, 0.1009 secs, 0.5613 secs
  resp read:	0.0001 secs, 0.0001 secs, 0.0015 secs

Status code distribution:
  [200]	100 responses
```